### PR TITLE
fix(generate): use type predicates from ajv instead of manual type annotations and fix localCompare usage

### DIFF
--- a/src/generate/generate.ts
+++ b/src/generate/generate.ts
@@ -56,9 +56,9 @@ const categorized = Object.entries(userstylesData.userstyles).reduce(
     acc[category] ||= [];
     acc[category].push({ path: `styles/${slug}`, category, ...port });
     acc[category].sort((a, b) => {
-      const a_name = typeof a.name === "string" ? a.name : a.name.join(", ");
-      const b_name = typeof b.name === "string" ? b.name : b.name.join(", ");
-      return a_name.localeCompare(b_name)
+      const aName = typeof a.name === "string" ? a.name : a.name.join(", ");
+      const bName = typeof b.name === "string" ? b.name : b.name.join(", ");
+      return aName.localeCompare(bName)
     });
     return acc;
   },

--- a/src/generate/generate.ts
+++ b/src/generate/generate.ts
@@ -29,7 +29,7 @@ type PortMetadata = {
 
 export type MappedPort = Userstyle & { path: string };
 
-const ajv = new Ajv();
+const ajv = new (Ajv as unknown as typeof Ajv["default"])();
 const validate = ajv.compile<Metadata>(schema);
 const validatePorts = ajv.compile<PortMetadata>(portsSchema);
 
@@ -55,7 +55,13 @@ const categorized = Object.entries(userstylesData.userstyles).reduce(
   (acc, [slug, { category, ...port }]) => {
     acc[category] ||= [];
     acc[category].push({ path: `styles/${slug}`, category, ...port });
-    acc[category].sort((a, b) => a.name.localeCompare(b.name));
+    acc[category].sort((a, b) => {
+      if (typeof a.name === "string" && typeof b.name === "string") {
+        return a.name.localeCompare(b.name)
+      } else {
+        return 0
+      }
+    });
     return acc;
   },
   {} as Record<string, MappedPort[]>

--- a/src/generate/generate.ts
+++ b/src/generate/generate.ts
@@ -56,11 +56,9 @@ const categorized = Object.entries(userstylesData.userstyles).reduce(
     acc[category] ||= [];
     acc[category].push({ path: `styles/${slug}`, category, ...port });
     acc[category].sort((a, b) => {
-      if (typeof a.name === "string" && typeof b.name === "string") {
-        return a.name.localeCompare(b.name)
-      } else {
-        return 0
-      }
+      const a_name = typeof a.name === "string" ? a.name : a.name.join(", ");
+      const b_name = typeof b.name === "string" ? b.name : b.name.join(", ");
+      return a_name.localeCompare(b_name)
     });
     return acc;
   },

--- a/src/generate/generate.ts
+++ b/src/generate/generate.ts
@@ -36,7 +36,7 @@ const validatePorts = ajv.compile<PortMetadata>(portsSchema);
 const userstylesYaml = Deno.readTextFileSync(
   path.join(ROOT, "../userstyles.yml")
 );
-const userstylesData: Metadata = parseYaml(userstylesYaml);
+const userstylesData = parseYaml(userstylesYaml);
 if (!validate(userstylesData)) {
   console.log(validate.errors);
   Deno.exit(1);
@@ -45,7 +45,7 @@ if (!validate(userstylesData)) {
 const portsYaml = await fetch(
   "https://raw.githubusercontent.com/catppuccin/catppuccin/main/resources/ports.yml"
 );
-const portsData: PortMetadata = parseYaml(await portsYaml.text());
+const portsData = parseYaml(await portsYaml.text());
 if (!validatePorts(portsData)) {
   console.log(validate.errors);
   Deno.exit(1);

--- a/src/generate/types.d.ts
+++ b/src/generate/types.d.ts
@@ -54,7 +54,7 @@ export type Icon = string;
 /**
  * The hyperlink of the app that is being themed
  */
-export type ApplicationLink = [unknown, unknown, ...unknown[]] | string;
+export type ApplicationLink = [string, string, ...string[]] | string;
 /**
  * The Usage section of the userstyle README
  */
@@ -127,7 +127,7 @@ export type AllMaintainers = [
   }[]
 ];
 
-export interface Demo {
+export interface UserstylesSchema {
   userstyles?: Userstyles;
   maintainers?: AllMaintainers;
 }

--- a/src/generate/types.d.ts
+++ b/src/generate/types.d.ts
@@ -8,7 +8,7 @@
 /**
  * The name of the userstyle(s).
  */
-export type Name = [unknown, unknown, ...unknown[]] | string;
+export type Name = [string, string, ...string[]] | string;
 /**
  * The category that fits the port the most.
  */

--- a/src/userstyles.schema.json
+++ b/src/userstyles.schema.json
@@ -109,6 +109,9 @@
                   "oneOf": [
                     {
                       "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
                       "minItems": 2,
                       "examples": [
                         [

--- a/src/userstyles.schema.json
+++ b/src/userstyles.schema.json
@@ -31,6 +31,9 @@
               "oneOf": [
                 {
                   "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
                   "minItems": 2,
                   "examples": [
                     [


### PR DESCRIPTION
The validate function that ajv generates has type predicates to narrow the type automatically
> compiled validation functions are type guards that narrow the type after successful validation.

[ajv TypeScript docs](https://ajv.js.org/guide/typescript.html)

https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates