### PR TITLE
refactor: support different types of collaborators

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,7 +21,7 @@
 #
 # /styles/lastfm @AnubisNekhet
 #
-# /styles/libreddit @andreasgrafen
+# /styles/libreddit @isabelroses
 #
 # /styles/mastodon @isabelroses
 #

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,19 +11,19 @@
 #
 # /styles/elk @ryanccn
 #
-# /styles/github @Pocco81 @GlowingUmbreon @andreasgrafen
+# /styles/github @Pocco81 @GlowingUmbreon
 #
 # /styles/hacker-news @lucasmelin
 #
 # /styles/ichi.moe @watatomo
 #
-# /styles/invidious @andreasgrafen @nekowinston
+# /styles/invidious @nekowinston
 #
 # /styles/lastfm @AnubisNekhet
 #
 # /styles/libreddit @andreasgrafen
 #
-# /styles/mastodon @andreasgrafen @isabelroses
+# /styles/mastodon @isabelroses
 #
 # /styles/modrinth @thismoon
 #
@@ -35,7 +35,7 @@
 #
 # /styles/reddit @jayylmao
 #
-# /styles/searxng @Sekki21956 @andreasgrafen @ryanccn
+# /styles/searxng @Sekki21956 @ryanccn
 #
 # /styles/tutanota @ryanccn
 #
@@ -45,4 +45,4 @@
 #
 # /styles/wikiwand @tnixc
 #
-# /styles/youtube @isabelroses @elkrien
+# /styles/youtube @isabelroses

--- a/README.md
+++ b/README.md
@@ -27,9 +27,14 @@
 </p>
 
 <p align="center">
-This repository is a curated collection of customized themes for different websites and web applications. 
-These themes feature delightful pastel colors that create a soothing and visually pleasing experience. 
-A userstyle, which is essentially a modified CSS file, is applied to a specific website to give it a unique and appealing aesthetic in accordance with Catppuccin's palette.
+This repository is a curated collection of customized themes designed for various websites and web applications. 
+These themes showcase delightful pastel colors, creating a soothing and visually pleasing experience when browsing the web.
+</p>
+
+<p align="center">
+<strong>Userstyles are essentially modified CSS files which can be applied to a specific website, 
+giving it a unique and appealing aesthetic in line with Catppuccino's color palette.</strong>
+</p>
 
 &nbsp;
 

--- a/docs/userstyle-creation.md
+++ b/docs/userstyle-creation.md
@@ -26,9 +26,9 @@ Creating userstyles should be very simple if you follow the instructions given b
 2. Create a new branch under the name `feat/<name-of-website>`, (e.g. `feat/nixos-search` instead of NixOS Search).
 3. Create a new folder `styles/<name-of-website>`. The name must be `lower-kebab-case`.
 4. Copy the contents of the [`template`](../template/) folder into `styles/<name-of-website>`.
-5. Edit the [`catppuccin.user.css`]() file and replace all the words wrapped with `<>` to fit the details of your port.
-6. Edit the [`userstyle.yml`]() file and put in the details of your port. **More details given below.**
-7. Create your image previews in the [`assets/`]() folder
+5. Edit the [`catppuccin.user.css`](../template/catppuccin.user.css) file and replace all the words wrapped with `<>` to fit the details of your port.
+6. Edit the [`userstyle.yml`](../src/userstyles.yml) file and put in the details of your port. **More details given below.**
+7. Create your image previews in the [`assets/`](../template/assets/) folder
    - **All previews must be `.webp` files.**
    - Create a preview image for each flavor. (e.g. `mocha.webp`, `macchiato.webp`, `frappe.webp` & `latte.webp`)
    - Use [catwalk](https://github.com/catppuccin/toolbox#catwalk) to generate a composite or grid image of all the flavors. **This must be saved as `catwalk.webp`.**

--- a/src/generate/generate.ts
+++ b/src/generate/generate.ts
@@ -12,7 +12,6 @@ import {
   Userstyle,
   CurrentMaintainers,
   PastMaintainers,
-  OtherContributors,
   Userstyles,
   Usage,
   ApplicationLink,
@@ -32,7 +31,7 @@ type PortMetadata = {
 };
 
 type CollaboratorsData = {
-  collaborators: CurrentMaintainers | PastMaintainers | OtherContributors;
+  collaborators: CurrentMaintainers | PastMaintainers;
   heading: string;
 };
 
@@ -245,10 +244,6 @@ const updateStylesReadmeContent = (
         {
           collaborators: userstyle.readme["past-maintainers"],
           heading: "## 💖 Past Maintainer(s)",
-        },
-        {
-          collaborators: userstyle.readme["other-contributors"],
-          heading: "## 💓 Other Contributor(s)",
         },
       ])
     );

--- a/src/generate/generate.ts
+++ b/src/generate/generate.ts
@@ -240,15 +240,15 @@ const updateStylesReadmeContent = (
       collaboratorsContent([
         {
           collaborators: userstyle.readme["current-maintainers"],
-          heading: "## 💝 Current Maintainers",
+          heading: "## 💝 Current Maintainer(s)",
         },
         {
           collaborators: userstyle.readme["past-maintainers"],
-          heading: "## 💖 Past Maintainers",
+          heading: "## 💖 Past Maintainer(s)",
         },
         {
           collaborators: userstyle.readme["other-contributors"],
-          heading: "## 💓 Other Contributors",
+          heading: "## 💓 Other Contributor(s)",
         },
       ])
     );

--- a/src/generate/generate.ts
+++ b/src/generate/generate.ts
@@ -218,7 +218,7 @@ const collaboratorsContent = (allCollaborators: CollaboratorsData[]) => {
     .filter(({ collaborators }) => collaborators !== undefined)
     .map(({ collaborators, heading }) => {
       const collaboratorBody = collaborators
-        .map(({ name, url }) => `- ${name ?? url.split("/").pop()}](${url})`)
+        .map(({ name, url }) => `- [${name ?? url.split("/").pop()}](${url})`)
         .join("\n");
       return `${heading}\n${collaboratorBody}`;
     })

--- a/src/generate/templates/userstyle.md
+++ b/src/generate/templates/userstyle.md
@@ -40,9 +40,7 @@ $USAGE
 
 $FAQ
 
-## 💝 Thanks to
-
-$MAINTAINERS
+$COLLABORATORS
 
 &nbsp;
 

--- a/src/generate/types.d.ts
+++ b/src/generate/types.d.ts
@@ -52,15 +52,15 @@ export type Color =
  */
 export type Icon = string;
 /**
- * The hyperlink of the app that is being themed
+ * The hyperlink of the app that is being themed.
  */
 export type ApplicationLink = [string, string, ...string[]] | string;
 /**
- * The Usage section of the userstyle README
+ * The Usage section of the userstyle README.
  */
 export type Usage = string;
 /**
- * The FAQ section of the userstyle README
+ * The FAQ section of the userstyle README.
  *
  * @minItems 1
  */
@@ -77,19 +77,19 @@ export type FAQ = [
   }[]
 ];
 /**
- * A question that a user may have about the userstyle
+ * A question that a user may have about the userstyle.
  */
 export type Question = string;
 /**
- * An answer to the question about the userstyle
+ * An answer to the question about the userstyle.
  */
 export type Answer = string;
 /**
- * List of all maintainers for this specific userstyle
+ * List of all active maintainers for this userstyle.
  *
  * @minItems 1
  */
-export type UserstyleMaintainers = [
+export type CurrentMaintainers = [
   {
     name?: DisplayName;
     url: GitHubProfile;
@@ -102,19 +102,53 @@ export type UserstyleMaintainers = [
   }[]
 ];
 /**
- * The display name of the maintainer to show in the userstyle README
+ * The display name of the collaborator to show in the userstyle README.
  */
 export type DisplayName = string;
 /**
- * The GitHub profile link of the maintainer to show in the userstyle README
+ * The GitHub profile link of the collaborator to show in the userstyle README.
  */
 export type GitHubProfile = string;
 /**
- * List of all maintainers within the userstyles repository
+ * List of all maintainers that have maintained on this userstyle in the past.
  *
  * @minItems 1
  */
-export type AllMaintainers = [
+export type PastMaintainers = [
+  {
+    name?: DisplayName;
+    url: GitHubProfile;
+    [k: string]: unknown;
+  },
+  ...{
+    name?: DisplayName;
+    url: GitHubProfile;
+    [k: string]: unknown;
+  }[]
+];
+/**
+ * List of all other contributors that have contributed to this userstyle.
+ *
+ * @minItems 1
+ */
+export type OtherContributors = [
+  {
+    name?: DisplayName;
+    url: GitHubProfile;
+    [k: string]: unknown;
+  },
+  ...{
+    name?: DisplayName;
+    url: GitHubProfile;
+    [k: string]: unknown;
+  }[]
+];
+/**
+ * Represents all maintainers and contributors to all userstyles.
+ *
+ * @minItems 1
+ */
+export type AllCollaborators = [
   {
     name?: DisplayName;
     url: GitHubProfile;
@@ -129,7 +163,7 @@ export type AllMaintainers = [
 
 export interface UserstylesSchema {
   userstyles?: Userstyles;
-  maintainers?: AllMaintainers;
+  collaborators?: AllCollaborators;
 }
 /**
  * All userstyles in the Catppuccin org.
@@ -151,12 +185,14 @@ export interface Userstyle {
   readme: README;
 }
 /**
- * Options to help in the auto-generation of the userstyle README
+ * Options to help in the auto-generation of the userstyle README.
  */
 export interface README {
   "app-link": ApplicationLink;
   usage?: Usage;
   faq?: FAQ;
-  maintainers: UserstyleMaintainers;
+  "current-maintainers": CurrentMaintainers;
+  "past-maintainers"?: PastMaintainers;
+  "other-contributors"?: OtherContributors;
   [k: string]: unknown;
 }

--- a/src/generate/types.d.ts
+++ b/src/generate/types.d.ts
@@ -127,23 +127,6 @@ export type PastMaintainers = [
   }[]
 ];
 /**
- * List of all other contributors that have contributed to this userstyle.
- *
- * @minItems 1
- */
-export type OtherContributors = [
-  {
-    name?: DisplayName;
-    url: GitHubProfile;
-    [k: string]: unknown;
-  },
-  ...{
-    name?: DisplayName;
-    url: GitHubProfile;
-    [k: string]: unknown;
-  }[]
-];
-/**
  * Represents all maintainers and contributors to all userstyles.
  *
  * @minItems 1
@@ -193,6 +176,5 @@ export interface README {
   faq?: FAQ;
   "current-maintainers": CurrentMaintainers;
   "past-maintainers"?: PastMaintainers;
-  "other-contributors"?: OtherContributors;
   [k: string]: unknown;
 }

--- a/src/userstyles.schema.json
+++ b/src/userstyles.schema.json
@@ -142,12 +142,6 @@
                   "title": "Past Maintainers",
                   "description": "List of all maintainers that have maintained on this userstyle in the past.",
                   "$ref": "#/$defs/collaborators"
-                },
-                "other-contributors": {
-                  "$id": "#userstyles/userstyle/readme/other-contributors",
-                  "title": "Other Contributors",
-                  "description": "List of all other contributors that have contributed to this userstyle.",
-                  "$ref": "#/$defs/collaborators"
                 }
               }
             }

--- a/src/userstyles.schema.json
+++ b/src/userstyles.schema.json
@@ -14,14 +14,8 @@
           "title": "Userstyle",
           "type": "object",
           "description": "The directory of the userstyle.",
-          "examples": [
-            "youtube"
-          ],
-          "required": [
-            "name",
-            "category",
-            "readme"
-          ],
+          "examples": ["youtube"],
+          "required": ["name", "category", "readme"],
           "additionalProperties": false,
           "properties": {
             "name": {
@@ -35,18 +29,11 @@
                     "type": "string"
                   },
                   "minItems": 2,
-                  "examples": [
-                    [
-                      "AniList",
-                      "AniChart"
-                    ]
-                  ]
+                  "examples": [["AniList", "AniChart"]]
                 },
                 {
                   "type": "string",
-                  "examples": [
-                    "YouTube"
-                  ]
+                  "examples": ["YouTube"]
                 }
               ]
             },
@@ -78,34 +65,26 @@
                 "lavender",
                 "text"
               ],
-              "examples": [
-                "pink"
-              ]
+              "examples": ["pink"]
             },
             "icon": {
               "$id": "#userstyles/userstyle/icon",
               "title": "Icon",
               "description": "The icon to use on the website. This should be the same name as the SVG file on https://simpleicons.org/. If a `.svg` suffix is present, it's taken from the local website repository resources.",
               "type": "string",
-              "examples": [
-                "twitch",
-                "twitch.svg"
-              ]
+              "examples": ["twitch", "twitch.svg"]
             },
             "readme": {
               "$id": "#userstyles/userstyle/readme",
               "title": "README",
-              "description": "Options to help in the auto-generation of the userstyle README",
+              "description": "Options to help in the auto-generation of the userstyle README.",
               "type": "object",
-              "required": [
-                "app-link",
-                "maintainers"
-              ],
+              "required": ["app-link", "current-maintainers"],
               "properties": {
                 "app-link": {
                   "$id": "#userstyles/userstyle/readme/app-link",
                   "title": "Application Link",
-                  "description": "The hyperlink of the app that is being themed",
+                  "description": "The hyperlink of the app that is being themed.",
                   "oneOf": [
                     {
                       "type": "array",
@@ -114,30 +93,25 @@
                       },
                       "minItems": 2,
                       "examples": [
-                        [
-                          "https://anilist.co",
-                          "https://anichart.net"
-                        ]
+                        ["https://anilist.co", "https://anichart.net"]
                       ]
                     },
                     {
                       "type": "string",
-                      "examples": [
-                        "https://github.com"
-                      ]
+                      "examples": ["https://github.com"]
                     }
                   ]
                 },
                 "usage": {
                   "$id": "#userstyles/userstyle/readme/usage",
                   "title": "Usage",
-                  "description": "The Usage section of the userstyle README",
+                  "description": "The Usage section of the userstyle README.",
                   "type": "string"
                 },
                 "faq": {
                   "$id": "#userstyles/userstyle/readme/faq",
                   "title": "FAQ",
-                  "description": "The FAQ section of the userstyle README",
+                  "description": "The FAQ section of the userstyle README.",
                   "type": "array",
                   "minItems": 1,
                   "items": {
@@ -146,25 +120,34 @@
                       "question": {
                         "type": "string",
                         "title": "Question",
-                        "description": "A question that a user may have about the userstyle"
+                        "description": "A question that a user may have about the userstyle."
                       },
                       "answer": {
                         "type": "string",
                         "title": "Answer",
-                        "description": "An answer to the question about the userstyle"
+                        "description": "An answer to the question about the userstyle."
                       }
                     },
-                    "required": [
-                      "question",
-                      "answer"
-                    ]
+                    "required": ["question", "answer"]
                   }
                 },
-                "maintainers": {
-                  "$id": "#userstyles/userstyle/readme/maintainers",
-                  "title": "Userstyle Maintainers",
-                  "description": "List of all maintainers for this specific userstyle",
-                  "$ref": "#/$defs/maintainers"
+                "current-maintainers": {
+                  "$id": "#userstyles/userstyle/readme/current-maintainers",
+                  "title": "Current Maintainers",
+                  "description": "List of all active maintainers for this userstyle.",
+                  "$ref": "#/$defs/collaborators"
+                },
+                "past-maintainers": {
+                  "$id": "#userstyles/userstyle/readme/past-maintainers",
+                  "title": "Past Maintainers",
+                  "description": "List of all maintainers that have maintained on this userstyle in the past.",
+                  "$ref": "#/$defs/collaborators"
+                },
+                "other-contributors": {
+                  "$id": "#userstyles/userstyle/readme/other-contributors",
+                  "title": "Other Contributors",
+                  "description": "List of all other contributors that have contributed to this userstyle.",
+                  "$ref": "#/$defs/collaborators"
                 }
               }
             }
@@ -172,16 +155,16 @@
         }
       }
     },
-    "maintainers": {
-      "$id": "#all-maintainers",
-      "title": "All Maintainers",
-      "description": "List of all maintainers within the userstyles repository",
-      "$ref": "#/$defs/maintainers"
+    "collaborators": {
+      "$id": "#all-collaborators",
+      "title": "All Collaborators",
+      "description": "Represents all maintainers and contributors to all userstyles.",
+      "$ref": "#/$defs/collaborators"
     }
   },
   "$defs": {
-    "maintainers": {
-      "$id": "#maintainers",
+    "collaborators": {
+      "$id": "#collaborators",
       "type": "array",
       "minItems": 1,
       "items": {
@@ -190,17 +173,15 @@
           "name": {
             "type": "string",
             "title": "Display Name",
-            "description": "The display name of the maintainer to show in the userstyle README"
+            "description": "The display name of the collaborator to show in the userstyle README."
           },
           "url": {
             "type": "string",
             "title": "GitHub Profile",
-            "description": "The GitHub profile link of the maintainer to show in the userstyle README"
+            "description": "The GitHub profile link of the collaborator to show in the userstyle README."
           }
         },
-        "required": [
-          "url"
-        ]
+        "required": ["url"]
       }
     },
     "category": {

--- a/src/userstyles.yml
+++ b/src/userstyles.yml
@@ -147,7 +147,8 @@ userstyles:
     color: peach
     readme:
       app-link: "https://github.com/libreddit/libreddit"
-      current-maintainers: [*andreasgrafen]
+      current-maintainers: [*isabelroses]
+      past-maintainers: [*andreasgrafen]
   mastodon:
     name: Mastodon
     category: social

--- a/src/userstyles.yml
+++ b/src/userstyles.yml
@@ -39,8 +39,6 @@ collaborators:
     url: https://github.com/soya-daizu
   - &jayylmao
     url: https://github.com/jayylmao
-  - &rubyowo
-    url: https://github.com/rubyowo
   - &sekki21956
     name: Sekki
     url: https://github.com/Sekki21956

--- a/src/userstyles.yml
+++ b/src/userstyles.yml
@@ -205,14 +205,12 @@ userstyles:
     readme:
       app-link: "https://reddit.com"
       current-maintainers: [*jayylmao]
-      other-contributors: [*rubyowo]
   searxng:
     name: SearXNG
     category: search_engine
     readme:
       app-link: "https://github.com/searxng/searxng"
       current-maintainers: [*sekki21956, *ryanccn]
-      other-contributors: [*winston, *andreasgrafen]
   tutanota:
     name: Tutanota
     category: productivity
@@ -247,7 +245,6 @@ userstyles:
     readme:
       app-link: "https://www.wikiwand.com"
       current-maintainers: [*tnixc]
-      other-contributors: [*rubyowo, *isabelroses]
   youtube:
     name: YouTube
     category: social
@@ -262,5 +259,4 @@ userstyles:
           answer: "It is there in-case you have an OLED display. If you have one, you might want to enable this."
       current-maintainers: [*isabelroses]
       past-maintainers: [*elkrien]
-      other-contributors: [*rubyowo]
 # yaml-language-server: $schema=userstyles.schema.json

--- a/src/userstyles.yml
+++ b/src/userstyles.yml
@@ -1,4 +1,4 @@
-maintainers:
+collaborators:
   - &anubisnekhet
     url: https://github.com/AnubisNekhet
   - &ndsboy
@@ -25,6 +25,8 @@ maintainers:
   - &lucasmelin
     name: Lucas Melin
     url: https://github.com/lucasmelin
+  - &gingeh
+    url: https://github.com/Gingeh
   - &isabelroses
     name: Isabel
     url: https://github.com/isabelroses
@@ -37,6 +39,8 @@ maintainers:
     url: https://github.com/soya-daizu
   - &jayylmao
     url: https://github.com/jayylmao
+  - &rubyowo
+    url: https://github.com/rubyowo
   - &sekki21956
     name: Sekki
     url: https://github.com/Sekki21956
@@ -54,15 +58,15 @@ maintainers:
 
 userstyles:
   anilist:
-    name: [ "AniList" , "AniChart" ]
+    name: ["AniList", "AniChart"]
     category: leisure
     color: blue
     readme:
-      app-link: [ "https://anilist.co", "https://anichart.net" ]
+      app-link: ["https://anilist.co", "https://anichart.net"]
       usage: |+
         > **Note** <br>
         > This theme applies to [AniChart](https://anichart.net/) as well, which is an extension of AniList.
-      maintainers: [ *anubisnekhet ]
+      current-maintainers: [*anubisnekhet]
   brave-search:
     name: Brave Search
     category: search_engine
@@ -71,13 +75,13 @@ userstyles:
     readme:
       app-link: "https://search.brave.com"
       usage: "Set theme to dark or light in Brave Search settings, the automatic setting will not work"
-      maintainers: [ *ndsboy ]
+      current-maintainers: [*ndsboy]
   cinny:
     name: Cinny
     category: messaging
     readme:
       app-link: "https://github.com/cinnyapo/cinny"
-      maintainers: [ *jn-sena ]
+      current-maintainers: [*jn-sena]
   codeberg:
     name: Codeberg
     category: productivity
@@ -86,39 +90,40 @@ userstyles:
       faq:
         - question: "How do I change the accent color?"
           answer: "Changing `--color-primary` to any other color should change the accent color in most places"
-      maintainers: [ *justtobbi ]
+      current-maintainers: [*justtobbi]
   deepl:
     name: DeepL
     category: productivity
     readme:
       app-link: "https://deepl.com"
-      maintainers: [ *watatomo ]
+      current-maintainers: [*watatomo]
   elk:
     name: Elk
     category: social
     readme:
       app-link: "https://elk.zone"
-      maintainers: [ *ryanccn ]
+      current-maintainers: [*ryanccn]
   github:
     name: GitHub
     category: productivity
     color: text
     readme:
       app-link: "https://github.com"
-      maintainers: [ *pocco81, *glowingumbreon, *andreasgrafen ]
+      current-maintainers: [*pocco81, *glowingumbreon]
+      past-maintainers: [*andreasgrafen]
   hacker-news:
     name: Hacker News
     category: social
     icon: ycombinator
     readme:
       app-link: "https://news.ycombinator.com/"
-      maintainers: [ *lucasmelin ]
+      current-maintainers: [*lucasmelin]
   ichi.moe:
     name: ichi.moe
     category: productivity
     readme:
       app-link: "https://ichi.moe"
-      maintainers: [ *watatomo ]
+      current-maintainers: [*watatomo]
   invidious:
     name: Invidious
     category: social
@@ -126,7 +131,8 @@ userstyles:
     color: red
     readme:
       app-link: "https://invidious.io"
-      maintainers: [ *andreasgrafen, *winston ]
+      current-maintainers: [*winston]
+      past-maintainers: [*andreasgrafen]
   lastfm:
     name: Last.fm
     category: leisure
@@ -134,7 +140,8 @@ userstyles:
     color: red
     readme:
       app-link: "https://last.fm"
-      maintainers: [ *anubisnekhet ]
+      current-maintainers: [*anubisnekhet]
+      past-maintainers: [*gingeh]
   libreddit:
     name: Libreddit
     category: social
@@ -142,7 +149,7 @@ userstyles:
     color: peach
     readme:
       app-link: "https://github.com/libreddit/libreddit"
-      maintainers: [ *andreasgrafen ]
+      current-maintainers: [*andreasgrafen]
   mastodon:
     name: Mastodon
     category: social
@@ -156,14 +163,15 @@ userstyles:
         - question: "**Theme is not working?**"
           answer: |
             One solution might be changing the theme from the `preferences > application > theme` to light or dark.
-      maintainers: [ *andreasgrafen, *isabelroses ]
+      current-maintainers: [*isabelroses]
+      past-maintainers: [*andreasgrafen]
   modrinth:
     name: Modrinth
     category: game
     color: green
     readme:
       app-link: "https://modrinth.com"
-      maintainers: [ *thismoon ]
+      current-maintainers: [*thismoon]
   nitter:
     name: Nitter
     category: social
@@ -171,7 +179,7 @@ userstyles:
     color: blue
     readme:
       app-link: "https://nitter.net"
-      maintainers: [ *anubisnekhet ]
+      current-maintainers: [*anubisnekhet]
   nixos-search:
     name: NixOS Search
     category: search_engine
@@ -179,7 +187,7 @@ userstyles:
     color: blue
     readme:
       app-link: "https://search.nixos.org"
-      maintainers: [ *alaidriel ]
+      current-maintainers: [*alaidriel]
   proton:
     name: Proton
     category: productivity
@@ -188,7 +196,7 @@ userstyles:
     readme:
       app-link: "https://proton.me/"
       usage: "Open Proton Mail and click the settings in the top right, then set the base theme to `Proton` if you are using the Latte flavor, otherwise set it to `Carbon`"
-      maintainers: [ *soya-daizu ]
+      current-maintainers: [*soya-daizu]
   reddit:
     name: Reddit
     category: social
@@ -196,13 +204,15 @@ userstyles:
     icon: reddit
     readme:
       app-link: "https://reddit.com"
-      maintainers: [ *jayylmao ]
+      current-maintainers: [*jayylmao]
+      other-contributors: [*rubyowo]
   searxng:
     name: SearXNG
     category: search_engine
     readme:
       app-link: "https://github.com/searxng/searxng"
-      maintainers: [ *sekki21956, *andreasgrafen, *ryanccn ]
+      current-maintainers: [*sekki21956, *ryanccn]
+      other-contributors: [*winston, *andreasgrafen]
   tutanota:
     name: Tutanota
     category: productivity
@@ -212,7 +222,7 @@ userstyles:
       usage: |+
         > **Note** <br>
         > Set Tutanota's built-in theme to either **light** if you're using Latte or **dark** if you're using the others.
-      maintainers: [ *ryanccn ]
+      current-maintainers: [*ryanccn]
   twitch:
     name: Twitch
     category: social
@@ -223,20 +233,21 @@ userstyles:
       usage: |+
         > **Note** <br>
         > Set Twitch's built-in theme to either **light** if you're using Latte or **dark** if you're using the others.
-      maintainers: [ *gitmuslim, *isabelroses ]
+      current-maintainers: [*gitmuslim, *isabelroses]
   vercel:
     name: Vercel
     category: development
     readme:
       app-link: "https://vercel.com"
-      maintainers: [ *ryanccn ]
+      current-maintainers: [*ryanccn]
   wikiwand:
     name: WikiWand
     category: productivity
     icon: wikipedia
     readme:
       app-link: "https://www.wikiwand.com"
-      maintainers: [ *tnixc ]
+      current-maintainers: [*tnixc]
+      other-contributors: [*rubyowo, *isabelroses]
   youtube:
     name: YouTube
     category: social
@@ -249,5 +260,7 @@ userstyles:
       faq:
         - question: "**What does the 'Enable for black bars' option mean?**"
           answer: "It is there in-case you have an OLED display. If you have one, you might want to enable this."
-      maintainers: [ *isabelroses, *elkrien ]
-# yaml-language-server: $schema=https://raw.githubusercontent.com/catppuccin/userstyles/main/src/userstyles.schema.json
+      current-maintainers: [*isabelroses]
+      past-maintainers: [*elkrien]
+      other-contributors: [*rubyowo]
+# yaml-language-server: $schema=userstyles.schema.json

--- a/styles/anilist/README.md
+++ b/styles/anilist/README.md
@@ -44,7 +44,7 @@
 
 
 ## 💝 Current Maintainers
-- AnubisNekhet](https://github.com/AnubisNekhet)
+- [AnubisNekhet](https://github.com/AnubisNekhet)
 
 &nbsp;
 

--- a/styles/anilist/README.md
+++ b/styles/anilist/README.md
@@ -43,9 +43,8 @@
 
 
 
-## 💝 Thanks to
-
-- [AnubisNekhet](https://github.com/AnubisNekhet)
+## 💝 Current Maintainers
+- AnubisNekhet](https://github.com/AnubisNekhet)
 
 &nbsp;
 

--- a/styles/anilist/README.md
+++ b/styles/anilist/README.md
@@ -43,7 +43,7 @@
 
 
 
-## 💝 Current Maintainers
+## 💝 Current Maintainer(s)
 - [AnubisNekhet](https://github.com/AnubisNekhet)
 
 &nbsp;

--- a/styles/brave-search/README.md
+++ b/styles/brave-search/README.md
@@ -41,9 +41,8 @@ Set theme to dark or light in Brave Search settings, the automatic setting will 
 
 
 
-## 💝 Thanks to
-
-- [ndsboy](https://github.com/ndsboy)
+## 💝 Current Maintainers
+- ndsboy](https://github.com/ndsboy)
 
 &nbsp;
 

--- a/styles/brave-search/README.md
+++ b/styles/brave-search/README.md
@@ -41,7 +41,7 @@ Set theme to dark or light in Brave Search settings, the automatic setting will 
 
 
 
-## 💝 Current Maintainers
+## 💝 Current Maintainer(s)
 - [ndsboy](https://github.com/ndsboy)
 
 &nbsp;

--- a/styles/brave-search/README.md
+++ b/styles/brave-search/README.md
@@ -42,7 +42,7 @@ Set theme to dark or light in Brave Search settings, the automatic setting will 
 
 
 ## 💝 Current Maintainers
-- ndsboy](https://github.com/ndsboy)
+- [ndsboy](https://github.com/ndsboy)
 
 &nbsp;
 

--- a/styles/cinny/README.md
+++ b/styles/cinny/README.md
@@ -40,7 +40,7 @@
 
 
 
-## 💝 Current Maintainers
+## 💝 Current Maintainer(s)
 - [jan Sena](https://github.com/jn-sena)
 
 &nbsp;

--- a/styles/cinny/README.md
+++ b/styles/cinny/README.md
@@ -40,9 +40,8 @@
 
 
 
-## 💝 Thanks to
-
-- [jan Sena](https://github.com/jn-sena)
+## 💝 Current Maintainers
+- jan Sena](https://github.com/jn-sena)
 
 &nbsp;
 

--- a/styles/cinny/README.md
+++ b/styles/cinny/README.md
@@ -41,7 +41,7 @@
 
 
 ## 💝 Current Maintainers
-- jan Sena](https://github.com/jn-sena)
+- [jan Sena](https://github.com/jn-sena)
 
 &nbsp;
 

--- a/styles/codeberg/README.md
+++ b/styles/codeberg/README.md
@@ -42,9 +42,8 @@
 - Q: How do I change the accent color?  
 	A: Changing `--color-primary` to any other color should change the accent color in most places
 
-## 💝 Thanks to
-
-- [justTOBBI](https://github.com/justTOBBI)
+## 💝 Current Maintainers
+- justTOBBI](https://github.com/justTOBBI)
 
 &nbsp;
 

--- a/styles/codeberg/README.md
+++ b/styles/codeberg/README.md
@@ -42,7 +42,7 @@
 - Q: How do I change the accent color?  
 	A: Changing `--color-primary` to any other color should change the accent color in most places
 
-## 💝 Current Maintainers
+## 💝 Current Maintainer(s)
 - [justTOBBI](https://github.com/justTOBBI)
 
 &nbsp;

--- a/styles/codeberg/README.md
+++ b/styles/codeberg/README.md
@@ -43,7 +43,7 @@
 	A: Changing `--color-primary` to any other color should change the accent color in most places
 
 ## 💝 Current Maintainers
-- justTOBBI](https://github.com/justTOBBI)
+- [justTOBBI](https://github.com/justTOBBI)
 
 &nbsp;
 

--- a/styles/deepl/README.md
+++ b/styles/deepl/README.md
@@ -40,7 +40,7 @@
 
 
 
-## 💝 Current Maintainers
+## 💝 Current Maintainer(s)
 - [Ren](https://github.com/watatomo)
 
 &nbsp;

--- a/styles/deepl/README.md
+++ b/styles/deepl/README.md
@@ -40,9 +40,8 @@
 
 
 
-## 💝 Thanks to
-
-- [Ren](https://github.com/watatomo)
+## 💝 Current Maintainers
+- Ren](https://github.com/watatomo)
 
 &nbsp;
 

--- a/styles/deepl/README.md
+++ b/styles/deepl/README.md
@@ -41,7 +41,7 @@
 
 
 ## 💝 Current Maintainers
-- Ren](https://github.com/watatomo)
+- [Ren](https://github.com/watatomo)
 
 &nbsp;
 

--- a/styles/elk/README.md
+++ b/styles/elk/README.md
@@ -40,9 +40,8 @@
 
 
 
-## 💝 Thanks to
-
-- [Ryan Cao](https://github.com/ryanccn)
+## 💝 Current Maintainers
+- Ryan Cao](https://github.com/ryanccn)
 
 &nbsp;
 

--- a/styles/elk/README.md
+++ b/styles/elk/README.md
@@ -40,7 +40,7 @@
 
 
 
-## 💝 Current Maintainers
+## 💝 Current Maintainer(s)
 - [Ryan Cao](https://github.com/ryanccn)
 
 &nbsp;

--- a/styles/elk/README.md
+++ b/styles/elk/README.md
@@ -41,7 +41,7 @@
 
 
 ## 💝 Current Maintainers
-- Ryan Cao](https://github.com/ryanccn)
+- [Ryan Cao](https://github.com/ryanccn)
 
 &nbsp;
 

--- a/styles/github/README.md
+++ b/styles/github/README.md
@@ -40,11 +40,12 @@
 
 
 
-## 💝 Thanks to
+## 💝 Current Maintainers
+- Pocco81](https://github.com/Pocco81)
+- Umbreon](https://github.com/GlowingUmbreon)
 
-- [Pocco81](https://github.com/Pocco81)
-- [Umbreon](https://github.com/GlowingUmbreon)
-- [Andreas Grafen](https://github.com/andreasgrafen)
+## 💖 Past Maintainers
+- Andreas Grafen](https://github.com/andreasgrafen)
 
 &nbsp;
 

--- a/styles/github/README.md
+++ b/styles/github/README.md
@@ -41,11 +41,11 @@
 
 
 ## 💝 Current Maintainers
-- Pocco81](https://github.com/Pocco81)
-- Umbreon](https://github.com/GlowingUmbreon)
+- [Pocco81](https://github.com/Pocco81)
+- [Umbreon](https://github.com/GlowingUmbreon)
 
 ## 💖 Past Maintainers
-- Andreas Grafen](https://github.com/andreasgrafen)
+- [Andreas Grafen](https://github.com/andreasgrafen)
 
 &nbsp;
 

--- a/styles/github/README.md
+++ b/styles/github/README.md
@@ -40,11 +40,11 @@
 
 
 
-## 💝 Current Maintainers
+## 💝 Current Maintainer(s)
 - [Pocco81](https://github.com/Pocco81)
 - [Umbreon](https://github.com/GlowingUmbreon)
 
-## 💖 Past Maintainers
+## 💖 Past Maintainer(s)
 - [Andreas Grafen](https://github.com/andreasgrafen)
 
 &nbsp;

--- a/styles/hacker-news/README.md
+++ b/styles/hacker-news/README.md
@@ -41,7 +41,7 @@
 
 
 ## 💝 Current Maintainers
-- Lucas Melin](https://github.com/lucasmelin)
+- [Lucas Melin](https://github.com/lucasmelin)
 
 &nbsp;
 

--- a/styles/hacker-news/README.md
+++ b/styles/hacker-news/README.md
@@ -40,9 +40,8 @@
 
 
 
-## 💝 Thanks to
-
-- [Lucas Melin](https://github.com/lucasmelin)
+## 💝 Current Maintainers
+- Lucas Melin](https://github.com/lucasmelin)
 
 &nbsp;
 

--- a/styles/hacker-news/README.md
+++ b/styles/hacker-news/README.md
@@ -40,7 +40,7 @@
 
 
 
-## 💝 Current Maintainers
+## 💝 Current Maintainer(s)
 - [Lucas Melin](https://github.com/lucasmelin)
 
 &nbsp;

--- a/styles/ichi.moe/README.md
+++ b/styles/ichi.moe/README.md
@@ -40,7 +40,7 @@
 
 
 
-## 💝 Current Maintainers
+## 💝 Current Maintainer(s)
 - [Ren](https://github.com/watatomo)
 
 &nbsp;

--- a/styles/ichi.moe/README.md
+++ b/styles/ichi.moe/README.md
@@ -40,9 +40,8 @@
 
 
 
-## 💝 Thanks to
-
-- [Ren](https://github.com/watatomo)
+## 💝 Current Maintainers
+- Ren](https://github.com/watatomo)
 
 &nbsp;
 

--- a/styles/ichi.moe/README.md
+++ b/styles/ichi.moe/README.md
@@ -41,7 +41,7 @@
 
 
 ## 💝 Current Maintainers
-- Ren](https://github.com/watatomo)
+- [Ren](https://github.com/watatomo)
 
 &nbsp;
 

--- a/styles/invidious/README.md
+++ b/styles/invidious/README.md
@@ -41,10 +41,10 @@
 
 
 ## 💝 Current Maintainers
-- winston](https://github.com/nekowinston)
+- [winston](https://github.com/nekowinston)
 
 ## 💖 Past Maintainers
-- Andreas Grafen](https://github.com/andreasgrafen)
+- [Andreas Grafen](https://github.com/andreasgrafen)
 
 &nbsp;
 

--- a/styles/invidious/README.md
+++ b/styles/invidious/README.md
@@ -40,10 +40,11 @@
 
 
 
-## 💝 Thanks to
+## 💝 Current Maintainers
+- winston](https://github.com/nekowinston)
 
-- [Andreas Grafen](https://github.com/andreasgrafen)
-- [winston](https://github.com/nekowinston)
+## 💖 Past Maintainers
+- Andreas Grafen](https://github.com/andreasgrafen)
 
 &nbsp;
 

--- a/styles/invidious/README.md
+++ b/styles/invidious/README.md
@@ -40,10 +40,10 @@
 
 
 
-## 💝 Current Maintainers
+## 💝 Current Maintainer(s)
 - [winston](https://github.com/nekowinston)
 
-## 💖 Past Maintainers
+## 💖 Past Maintainer(s)
 - [Andreas Grafen](https://github.com/andreasgrafen)
 
 &nbsp;

--- a/styles/lastfm/README.md
+++ b/styles/lastfm/README.md
@@ -40,10 +40,10 @@
 
 
 
-## 💝 Current Maintainers
+## 💝 Current Maintainer(s)
 - [AnubisNekhet](https://github.com/AnubisNekhet)
 
-## 💖 Past Maintainers
+## 💖 Past Maintainer(s)
 - [Gingeh](https://github.com/Gingeh)
 
 &nbsp;

--- a/styles/lastfm/README.md
+++ b/styles/lastfm/README.md
@@ -40,9 +40,11 @@
 
 
 
-## 💝 Thanks to
+## 💝 Current Maintainers
+- AnubisNekhet](https://github.com/AnubisNekhet)
 
-- [AnubisNekhet](https://github.com/AnubisNekhet)
+## 💖 Past Maintainers
+- Gingeh](https://github.com/Gingeh)
 
 &nbsp;
 

--- a/styles/lastfm/README.md
+++ b/styles/lastfm/README.md
@@ -41,10 +41,10 @@
 
 
 ## 💝 Current Maintainers
-- AnubisNekhet](https://github.com/AnubisNekhet)
+- [AnubisNekhet](https://github.com/AnubisNekhet)
 
 ## 💖 Past Maintainers
-- Gingeh](https://github.com/Gingeh)
+- [Gingeh](https://github.com/Gingeh)
 
 &nbsp;
 

--- a/styles/libreddit/README.md
+++ b/styles/libreddit/README.md
@@ -40,7 +40,7 @@
 
 
 
-## 💝 Current Maintainers
+## 💝 Current Maintainer(s)
 - [Andreas Grafen](https://github.com/andreasgrafen)
 
 &nbsp;

--- a/styles/libreddit/README.md
+++ b/styles/libreddit/README.md
@@ -40,9 +40,8 @@
 
 
 
-## 💝 Thanks to
-
-- [Andreas Grafen](https://github.com/andreasgrafen)
+## 💝 Current Maintainers
+- Andreas Grafen](https://github.com/andreasgrafen)
 
 &nbsp;
 

--- a/styles/libreddit/README.md
+++ b/styles/libreddit/README.md
@@ -41,7 +41,7 @@
 
 
 ## 💝 Current Maintainers
-- Andreas Grafen](https://github.com/andreasgrafen)
+- [Andreas Grafen](https://github.com/andreasgrafen)
 
 &nbsp;
 

--- a/styles/libreddit/README.md
+++ b/styles/libreddit/README.md
@@ -41,6 +41,9 @@
 
 
 ## 💝 Current Maintainer(s)
+- [Isabel](https://github.com/isabelroses)
+
+## 💖 Past Maintainer(s)
 - [Andreas Grafen](https://github.com/andreasgrafen)
 
 &nbsp;

--- a/styles/mastodon/README.md
+++ b/styles/mastodon/README.md
@@ -47,10 +47,11 @@ Add urls to `@-moz-document domain("url")` with url being the chosen server
 	A: One solution might be changing the theme from the `preferences > application > theme` to light or dark.
 
 
-## 💝 Thanks to
+## 💝 Current Maintainers
+- Isabel](https://github.com/isabelroses)
 
-- [Andreas Grafen](https://github.com/andreasgrafen)
-- [Isabel](https://github.com/isabelroses)
+## 💖 Past Maintainers
+- Andreas Grafen](https://github.com/andreasgrafen)
 
 &nbsp;
 

--- a/styles/mastodon/README.md
+++ b/styles/mastodon/README.md
@@ -48,10 +48,10 @@ Add urls to `@-moz-document domain("url")` with url being the chosen server
 
 
 ## 💝 Current Maintainers
-- Isabel](https://github.com/isabelroses)
+- [Isabel](https://github.com/isabelroses)
 
 ## 💖 Past Maintainers
-- Andreas Grafen](https://github.com/andreasgrafen)
+- [Andreas Grafen](https://github.com/andreasgrafen)
 
 &nbsp;
 

--- a/styles/mastodon/README.md
+++ b/styles/mastodon/README.md
@@ -47,10 +47,10 @@ Add urls to `@-moz-document domain("url")` with url being the chosen server
 	A: One solution might be changing the theme from the `preferences > application > theme` to light or dark.
 
 
-## 💝 Current Maintainers
+## 💝 Current Maintainer(s)
 - [Isabel](https://github.com/isabelroses)
 
-## 💖 Past Maintainers
+## 💖 Past Maintainer(s)
 - [Andreas Grafen](https://github.com/andreasgrafen)
 
 &nbsp;

--- a/styles/modrinth/README.md
+++ b/styles/modrinth/README.md
@@ -41,7 +41,7 @@
 
 
 ## 💝 Current Maintainers
-- thismoon](https://github.com/thismoon)
+- [thismoon](https://github.com/thismoon)
 
 &nbsp;
 

--- a/styles/modrinth/README.md
+++ b/styles/modrinth/README.md
@@ -40,9 +40,8 @@
 
 
 
-## 💝 Thanks to
-
-- [thismoon](https://github.com/thismoon)
+## 💝 Current Maintainers
+- thismoon](https://github.com/thismoon)
 
 &nbsp;
 

--- a/styles/modrinth/README.md
+++ b/styles/modrinth/README.md
@@ -40,7 +40,7 @@
 
 
 
-## 💝 Current Maintainers
+## 💝 Current Maintainer(s)
 - [thismoon](https://github.com/thismoon)
 
 &nbsp;

--- a/styles/nitter/README.md
+++ b/styles/nitter/README.md
@@ -40,9 +40,8 @@
 
 
 
-## 💝 Thanks to
-
-- [AnubisNekhet](https://github.com/AnubisNekhet)
+## 💝 Current Maintainers
+- AnubisNekhet](https://github.com/AnubisNekhet)
 
 &nbsp;
 

--- a/styles/nitter/README.md
+++ b/styles/nitter/README.md
@@ -40,7 +40,7 @@
 
 
 
-## 💝 Current Maintainers
+## 💝 Current Maintainer(s)
 - [AnubisNekhet](https://github.com/AnubisNekhet)
 
 &nbsp;

--- a/styles/nitter/README.md
+++ b/styles/nitter/README.md
@@ -41,7 +41,7 @@
 
 
 ## 💝 Current Maintainers
-- AnubisNekhet](https://github.com/AnubisNekhet)
+- [AnubisNekhet](https://github.com/AnubisNekhet)
 
 &nbsp;
 

--- a/styles/nixos-search/README.md
+++ b/styles/nixos-search/README.md
@@ -41,7 +41,7 @@
 
 
 ## 💝 Current Maintainers
-- alaidriel](https://github.com/alaidriel)
+- [alaidriel](https://github.com/alaidriel)
 
 &nbsp;
 

--- a/styles/nixos-search/README.md
+++ b/styles/nixos-search/README.md
@@ -40,9 +40,8 @@
 
 
 
-## 💝 Thanks to
-
-- [alaidriel](https://github.com/alaidriel)
+## 💝 Current Maintainers
+- alaidriel](https://github.com/alaidriel)
 
 &nbsp;
 

--- a/styles/nixos-search/README.md
+++ b/styles/nixos-search/README.md
@@ -40,7 +40,7 @@
 
 
 
-## 💝 Current Maintainers
+## 💝 Current Maintainer(s)
 - [alaidriel](https://github.com/alaidriel)
 
 &nbsp;

--- a/styles/proton/README.md
+++ b/styles/proton/README.md
@@ -41,7 +41,7 @@ Open Proton Mail and click the settings in the top right, then set the base them
 
 
 
-## 💝 Current Maintainers
+## 💝 Current Maintainer(s)
 - [soya_daizu](https://github.com/soya-daizu)
 
 &nbsp;

--- a/styles/proton/README.md
+++ b/styles/proton/README.md
@@ -41,9 +41,8 @@ Open Proton Mail and click the settings in the top right, then set the base them
 
 
 
-## 💝 Thanks to
-
-- [soya_daizu](https://github.com/soya-daizu)
+## 💝 Current Maintainers
+- soya_daizu](https://github.com/soya-daizu)
 
 &nbsp;
 

--- a/styles/proton/README.md
+++ b/styles/proton/README.md
@@ -42,7 +42,7 @@ Open Proton Mail and click the settings in the top right, then set the base them
 
 
 ## 💝 Current Maintainers
-- soya_daizu](https://github.com/soya-daizu)
+- [soya_daizu](https://github.com/soya-daizu)
 
 &nbsp;
 

--- a/styles/reddit/README.md
+++ b/styles/reddit/README.md
@@ -41,10 +41,10 @@
 
 
 ## 💝 Current Maintainers
-- jayylmao](https://github.com/jayylmao)
+- [jayylmao](https://github.com/jayylmao)
 
 ## 💓 Other Contributors
-- rubyowo](https://github.com/rubyowo)
+- [rubyowo](https://github.com/rubyowo)
 
 &nbsp;
 

--- a/styles/reddit/README.md
+++ b/styles/reddit/README.md
@@ -40,10 +40,10 @@
 
 
 
-## 💝 Current Maintainers
+## 💝 Current Maintainer(s)
 - [jayylmao](https://github.com/jayylmao)
 
-## 💓 Other Contributors
+## 💓 Other Contributor(s)
 - [rubyowo](https://github.com/rubyowo)
 
 &nbsp;

--- a/styles/reddit/README.md
+++ b/styles/reddit/README.md
@@ -40,9 +40,11 @@
 
 
 
-## 💝 Thanks to
+## 💝 Current Maintainers
+- jayylmao](https://github.com/jayylmao)
 
-- [jayylmao](https://github.com/jayylmao)
+## 💓 Other Contributors
+- rubyowo](https://github.com/rubyowo)
 
 &nbsp;
 

--- a/styles/reddit/README.md
+++ b/styles/reddit/README.md
@@ -43,9 +43,6 @@
 ## 💝 Current Maintainer(s)
 - [jayylmao](https://github.com/jayylmao)
 
-## 💓 Other Contributor(s)
-- [rubyowo](https://github.com/rubyowo)
-
 &nbsp;
 
 <p align="center">

--- a/styles/searxng/README.md
+++ b/styles/searxng/README.md
@@ -40,11 +40,11 @@
 
 
 
-## 💝 Current Maintainers
+## 💝 Current Maintainer(s)
 - [Sekki](https://github.com/Sekki21956)
 - [Ryan Cao](https://github.com/ryanccn)
 
-## 💓 Other Contributors
+## 💓 Other Contributor(s)
 - [winston](https://github.com/nekowinston)
 - [Andreas Grafen](https://github.com/andreasgrafen)
 

--- a/styles/searxng/README.md
+++ b/styles/searxng/README.md
@@ -40,11 +40,13 @@
 
 
 
-## 💝 Thanks to
+## 💝 Current Maintainers
+- Sekki](https://github.com/Sekki21956)
+- Ryan Cao](https://github.com/ryanccn)
 
-- [Sekki](https://github.com/Sekki21956)
-- [Andreas Grafen](https://github.com/andreasgrafen)
-- [Ryan Cao](https://github.com/ryanccn)
+## 💓 Other Contributors
+- winston](https://github.com/nekowinston)
+- Andreas Grafen](https://github.com/andreasgrafen)
 
 &nbsp;
 

--- a/styles/searxng/README.md
+++ b/styles/searxng/README.md
@@ -44,10 +44,6 @@
 - [Sekki](https://github.com/Sekki21956)
 - [Ryan Cao](https://github.com/ryanccn)
 
-## 💓 Other Contributor(s)
-- [winston](https://github.com/nekowinston)
-- [Andreas Grafen](https://github.com/andreasgrafen)
-
 &nbsp;
 
 <p align="center">

--- a/styles/searxng/README.md
+++ b/styles/searxng/README.md
@@ -41,12 +41,12 @@
 
 
 ## 💝 Current Maintainers
-- Sekki](https://github.com/Sekki21956)
-- Ryan Cao](https://github.com/ryanccn)
+- [Sekki](https://github.com/Sekki21956)
+- [Ryan Cao](https://github.com/ryanccn)
 
 ## 💓 Other Contributors
-- winston](https://github.com/nekowinston)
-- Andreas Grafen](https://github.com/andreasgrafen)
+- [winston](https://github.com/nekowinston)
+- [Andreas Grafen](https://github.com/andreasgrafen)
 
 &nbsp;
 

--- a/styles/tutanota/README.md
+++ b/styles/tutanota/README.md
@@ -43,9 +43,8 @@
 
 
 
-## 💝 Thanks to
-
-- [Ryan Cao](https://github.com/ryanccn)
+## 💝 Current Maintainers
+- Ryan Cao](https://github.com/ryanccn)
 
 &nbsp;
 

--- a/styles/tutanota/README.md
+++ b/styles/tutanota/README.md
@@ -43,7 +43,7 @@
 
 
 
-## 💝 Current Maintainers
+## 💝 Current Maintainer(s)
 - [Ryan Cao](https://github.com/ryanccn)
 
 &nbsp;

--- a/styles/tutanota/README.md
+++ b/styles/tutanota/README.md
@@ -44,7 +44,7 @@
 
 
 ## 💝 Current Maintainers
-- Ryan Cao](https://github.com/ryanccn)
+- [Ryan Cao](https://github.com/ryanccn)
 
 &nbsp;
 

--- a/styles/twitch/README.md
+++ b/styles/twitch/README.md
@@ -43,10 +43,9 @@
 
 
 
-## 💝 Thanks to
-
-- [GitMuslim](https://github.com/GitMuslim)
-- [Isabel](https://github.com/isabelroses)
+## 💝 Current Maintainers
+- GitMuslim](https://github.com/GitMuslim)
+- Isabel](https://github.com/isabelroses)
 
 &nbsp;
 

--- a/styles/twitch/README.md
+++ b/styles/twitch/README.md
@@ -43,7 +43,7 @@
 
 
 
-## 💝 Current Maintainers
+## 💝 Current Maintainer(s)
 - [GitMuslim](https://github.com/GitMuslim)
 - [Isabel](https://github.com/isabelroses)
 

--- a/styles/twitch/README.md
+++ b/styles/twitch/README.md
@@ -44,8 +44,8 @@
 
 
 ## 💝 Current Maintainers
-- GitMuslim](https://github.com/GitMuslim)
-- Isabel](https://github.com/isabelroses)
+- [GitMuslim](https://github.com/GitMuslim)
+- [Isabel](https://github.com/isabelroses)
 
 &nbsp;
 

--- a/styles/vercel/README.md
+++ b/styles/vercel/README.md
@@ -40,9 +40,8 @@
 
 
 
-## 💝 Thanks to
-
-- [Ryan Cao](https://github.com/ryanccn)
+## 💝 Current Maintainers
+- Ryan Cao](https://github.com/ryanccn)
 
 &nbsp;
 

--- a/styles/vercel/README.md
+++ b/styles/vercel/README.md
@@ -40,7 +40,7 @@
 
 
 
-## 💝 Current Maintainers
+## 💝 Current Maintainer(s)
 - [Ryan Cao](https://github.com/ryanccn)
 
 &nbsp;

--- a/styles/vercel/README.md
+++ b/styles/vercel/README.md
@@ -41,7 +41,7 @@
 
 
 ## 💝 Current Maintainers
-- Ryan Cao](https://github.com/ryanccn)
+- [Ryan Cao](https://github.com/ryanccn)
 
 &nbsp;
 

--- a/styles/wikiwand/README.md
+++ b/styles/wikiwand/README.md
@@ -43,10 +43,6 @@
 ## 💝 Current Maintainer(s)
 - [Tnixc](https://github.com/tnixc)
 
-## 💓 Other Contributor(s)
-- [rubyowo](https://github.com/rubyowo)
-- [Isabel](https://github.com/isabelroses)
-
 &nbsp;
 
 <p align="center">

--- a/styles/wikiwand/README.md
+++ b/styles/wikiwand/README.md
@@ -40,9 +40,12 @@
 
 
 
-## 💝 Thanks to
+## 💝 Current Maintainers
+- Tnixc](https://github.com/tnixc)
 
-- [Tnixc](https://github.com/tnixc)
+## 💓 Other Contributors
+- rubyowo](https://github.com/rubyowo)
+- Isabel](https://github.com/isabelroses)
 
 &nbsp;
 

--- a/styles/wikiwand/README.md
+++ b/styles/wikiwand/README.md
@@ -41,11 +41,11 @@
 
 
 ## 💝 Current Maintainers
-- Tnixc](https://github.com/tnixc)
+- [Tnixc](https://github.com/tnixc)
 
 ## 💓 Other Contributors
-- rubyowo](https://github.com/rubyowo)
-- Isabel](https://github.com/isabelroses)
+- [rubyowo](https://github.com/rubyowo)
+- [Isabel](https://github.com/isabelroses)
 
 &nbsp;
 

--- a/styles/wikiwand/README.md
+++ b/styles/wikiwand/README.md
@@ -40,10 +40,10 @@
 
 
 
-## 💝 Current Maintainers
+## 💝 Current Maintainer(s)
 - [Tnixc](https://github.com/tnixc)
 
-## 💓 Other Contributors
+## 💓 Other Contributor(s)
 - [rubyowo](https://github.com/rubyowo)
 - [Isabel](https://github.com/isabelroses)
 

--- a/styles/youtube/README.md
+++ b/styles/youtube/README.md
@@ -46,13 +46,13 @@
 	A: It is there in-case you have an OLED display. If you have one, you might want to enable this.
 
 ## 💝 Current Maintainers
-- Isabel](https://github.com/isabelroses)
+- [Isabel](https://github.com/isabelroses)
 
 ## 💖 Past Maintainers
-- Elkrien](https://github.com/elkrien)
+- [Elkrien](https://github.com/elkrien)
 
 ## 💓 Other Contributors
-- rubyowo](https://github.com/rubyowo)
+- [rubyowo](https://github.com/rubyowo)
 
 &nbsp;
 

--- a/styles/youtube/README.md
+++ b/styles/youtube/README.md
@@ -45,10 +45,14 @@
 - Q: **What does the 'Enable for black bars' option mean?**  
 	A: It is there in-case you have an OLED display. If you have one, you might want to enable this.
 
-## 💝 Thanks to
+## 💝 Current Maintainers
+- Isabel](https://github.com/isabelroses)
 
-- [Isabel](https://github.com/isabelroses)
-- [Elkrien](https://github.com/elkrien)
+## 💖 Past Maintainers
+- Elkrien](https://github.com/elkrien)
+
+## 💓 Other Contributors
+- rubyowo](https://github.com/rubyowo)
 
 &nbsp;
 

--- a/styles/youtube/README.md
+++ b/styles/youtube/README.md
@@ -51,9 +51,6 @@
 ## 💖 Past Maintainer(s)
 - [Elkrien](https://github.com/elkrien)
 
-## 💓 Other Contributor(s)
-- [rubyowo](https://github.com/rubyowo)
-
 &nbsp;
 
 <p align="center">

--- a/styles/youtube/README.md
+++ b/styles/youtube/README.md
@@ -45,13 +45,13 @@
 - Q: **What does the 'Enable for black bars' option mean?**  
 	A: It is there in-case you have an OLED display. If you have one, you might want to enable this.
 
-## 💝 Current Maintainers
+## 💝 Current Maintainer(s)
 - [Isabel](https://github.com/isabelroses)
 
-## 💖 Past Maintainers
+## 💖 Past Maintainer(s)
 - [Elkrien](https://github.com/elkrien)
 
-## 💓 Other Contributors
+## 💓 Other Contributor(s)
 - [rubyowo](https://github.com/rubyowo)
 
 &nbsp;


### PR DESCRIPTION
This commit refactors the schema to allow `current-maintainers`, `past-maintainers` and `other-contributors` to be defined.
